### PR TITLE
Add bsd license header

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,7 +44,7 @@ Flags:
 
 var (
 	holder  = flag.String("c", "Google Inc.", "copyright holder")
-	license = flag.String("l", "apache", "license type: apache, mit")
+	license = flag.String("l", "apache", "license type: apache, bsd, mit")
 	year    = flag.Int("y", time.Now().Year(), "year")
 )
 

--- a/tmpl.go
+++ b/tmpl.go
@@ -25,6 +25,7 @@ var licenseTemplate = make(map[string]*template.Template)
 func init() {
 	licenseTemplate["apache"] = template.Must(template.New("").Parse(tmplApache))
 	licenseTemplate["mit"] = template.Must(template.New("").Parse(tmplMIT))
+	licenseTemplate["bsd"] = template.Must(template.New("").Parse(tmplBSD))
 }
 
 type copyrightData struct {
@@ -77,6 +78,10 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.`
+
+const tmplBSD = `Copyright (c) {{.Year}} {{.Holder}} All rights reserved.
+Use of this source code is governed by a BSD-style
+license that can be found in the LICENSE file.`
 
 const tmplMIT = `Copyright (c) {{.Year}} {{.Holder}}
 


### PR DESCRIPTION
This adds the BSD license header used by many Go projects (Go, Upspin, etc)

> Copyright {{.Year}} {{.Holder}}. All rights reserved.
Use of this source code is governed by a BSD-style
license that can be found in the LICENSE file.

