### PR TITLE
Change default copyright holder to Google LLC

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ Flags:
 `
 
 var (
-	holder  = flag.String("c", "Google Inc.", "copyright holder")
+	holder  = flag.String("c", "Google LLC", "copyright holder")
 	license = flag.String("l", "apache", "license type: apache, bsd, mit")
 	year    = flag.Int("y", time.Now().Year(), "year")
 )


### PR DESCRIPTION
As per OSPO, this is the new default name for Google copyright ownership.