### PR TITLE
Better support for XML and HTML

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 )
@@ -155,6 +156,12 @@ func addLicense(path string, fmode os.FileMode, typ string, data *copyrightData)
 	return ioutil.WriteFile(path, b, fmode)
 }
 
+var head = []string{
+	"#!",        // shell script
+	"<?xml",     // XML declaratioon
+	"<!doctype", // HTML doctype
+}
+
 func hashBang(b []byte) []byte {
 	var line []byte
 	for _, c := range b {
@@ -163,8 +170,11 @@ func hashBang(b []byte) []byte {
 			break
 		}
 	}
-	if bytes.HasPrefix(line, []byte("#!")) {
-		return line
+	first := strings.ToLower(string(line))
+	for _, h := range head {
+		if strings.HasPrefix(first, h) {
+			return line
+		}
 	}
 	return nil
 }

--- a/testdata/expected/file2.xml
+++ b/testdata/expected/file2.xml
@@ -1,13 +1,13 @@
-<!doctype html>
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <!--
  Copyright 2016 Google Inc.
- 
+
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
- 
+
       http://www.apache.org/licenses/LICENSE-2.0
- 
+
  Unless required by applicable law or agreed to in writing, software
  distributed under the License is distributed on an "AS IS" BASIS,
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,4 +15,7 @@
  limitations under the License.
 -->
 
-<p>Hello World!</p>
+<root>
+	<one>one</one>
+	<two/>
+</root>

--- a/testdata/initial/file2.xml
+++ b/testdata/initial/file2.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<root>
+	<one>one</one>
+	<two/>
+</root>


### PR DESCRIPTION
Keep `<?xml` and `<!doctype` declarations.

Fixes #5.