### PR TITLE
Switch year arg from int to string

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ var (
 	holder   = flag.String("c", "Google LLC", "copyright holder")
 	license  = flag.String("l", "apache", "license type: apache, bsd, mit")
 	licensef = flag.String("f", "", "license file")
-	year     = flag.Int("y", time.Now().Year(), "year")
+	year     = flag.String("y", fmt.Sprint(time.Now().Year()), "copyright year(s)")
 )
 
 func main() {

--- a/main_test.go
+++ b/main_test.go
@@ -63,3 +63,27 @@ func TestInitial(t *testing.T) {
 		run(t, "diff", "-r", filepath.Join(tmp, "initial"), "testdata/expected")
 	}
 }
+
+func TestMultiyear(t *testing.T) {
+	if os.Getenv("RUNME") != "" {
+		main()
+		return
+	}
+
+	tmp := tempDir(t)
+	t.Logf("tmp dir: %s", tmp)
+	samplefile := filepath.Join(tmp, "file.c")
+	const sampleLicensed = "testdata/multiyear_file.c"
+
+	run(t, "cp", "testdata/initial/file.c", samplefile)
+	cmd := exec.Command(os.Args[0],
+		"-test.run=TestMultiyear",
+		"-l", "bsd", "-c", "Google LLC",
+		"-y", "2015-2017,2019", samplefile,
+	)
+	cmd.Env = []string{"RUNME=1"}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%v\n%s", err, out)
+	}
+	run(t, "diff", samplefile, sampleLicensed)
+}

--- a/testdata/multiyear_file.c
+++ b/testdata/multiyear_file.c
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2015-2017,2019 Google LLC All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
+#include <stdio.h>
+
+int main() {
+	printf("Hello world\n");
+	return 0;
+}

--- a/tmpl.go
+++ b/tmpl.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 type copyrightData struct {
-	Year   int
+	Year   string
 	Holder string
 }
 


### PR DESCRIPTION
This effectively allows for arbitrary copyright years. For instance, 2018-2019.

Based on #18.
Fixes #17.

/cc @cryptocode