### PR TITLE
Update .php handling to keep <?php at the top

### DIFF
--- a/main.go
+++ b/main.go
@@ -222,7 +222,7 @@ func licenseHeader(path string, tmpl *template.Template, data *copyrightData) ([
 	case ".html", ".xml":
 		lic, err = prefix(tmpl, data, "<!--", " ", "-->")
 	case ".php":
-		lic, err = prefix(tmpl, data, "<?php", "// ", "?>")
+		lic, err = prefix(tmpl, data, "", "// ", "")
 	case ".ml", ".mli", ".mll", ".mly":
 		lic, err = prefix(tmpl, data, "(**", "   ", "*)")
 	}
@@ -242,6 +242,7 @@ var head = []string{
 	"<!doctype",                // HTML doctype
 	"# encoding:",              // Ruby encoding
 	"# frozen_string_literal:", // Ruby interpreter instruction
+	"<?php",                    // PHP opening tag
 }
 
 func hashBang(b []byte) []byte {

--- a/testdata/expected/file.php
+++ b/testdata/expected/file.php
@@ -12,6 +12,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-?>
 
-<?php phpinfo(); ?>
+namespace App;
+phpinfo();

--- a/testdata/initial/file.php
+++ b/testdata/initial/file.php
@@ -1,1 +1,3 @@
-<?php phpinfo(); ?>
+<?php
+namespace App;
+phpinfo();


### PR DESCRIPTION
Looking at https://www.php.net/manual/en/language.basic-syntax.phptags.php
there are just too many variations and I'm not convinced the added
complexity to support all of them would be worth it here.

Thus, support only the case where closing tag "?>" is either omitted
or on a separate line. A workaround for all other cases is to add
the license header manually.

Can always revisit this later.

Closes https://github.com/google/addlicense/issues/30.