### PR TITLE
MPL license support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ to any file that already has one.
 
     -c copyright holder (defaults to "Google LLC")
     -f custom license file (no default)
-    -l license type: apache, bsd, mit (defaults to "apache")
+    -l license type: apache, bsd, mit, mpl (defaults to "apache")
     -y year (defaults to current year)
     -check check only mode: verify presence of license headers and exit with non-zero code if missing
 

--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ Flags:
 
 var (
 	holder    = flag.String("c", "Google LLC", "copyright holder")
-	license   = flag.String("l", "apache", "license type: apache, bsd, mit")
+	license   = flag.String("l", "apache", "license type: apache, bsd, mit, mpl")
 	licensef  = flag.String("f", "", "license file")
 	year      = flag.String("y", fmt.Sprint(time.Now().Year()), "copyright year(s)")
 	verbose   = flag.Bool("v", false, "verbose mode: print the name of the files that are modified")
@@ -267,5 +267,6 @@ func hasLicense(b []byte) bool {
 	if len(b) < 1000 {
 		n = len(b)
 	}
-	return bytes.Contains(bytes.ToLower(b[:n]), []byte("copyright"))
+	return bytes.Contains(bytes.ToLower(b[:n]), []byte("copyright")) ||
+		bytes.Contains(bytes.ToLower(b[:n]), []byte("mozilla public"))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -184,3 +184,25 @@ func TestCheckFail(t *testing.T) {
 		t.Fatalf("TestCheckFail exited with a zero exit code.\n%s", out)
 	}
 }
+
+func TestMPL(t *testing.T) {
+	if os.Getenv("RUNME") != "" {
+		main()
+		return
+	}
+
+	tmp := tempDir(t)
+	t.Logf("tmp dir: %s", tmp)
+	samplefile := filepath.Join(tmp, "file.c")
+
+	run(t, "cp", "testdata/expected/file.c", samplefile)
+	cmd := exec.Command(os.Args[0],
+		"-test.run=TestMPL",
+		"-l", "mpl", "-c", "Google LLC", "-y", "2018",
+		"-check", samplefile,
+	)
+	cmd.Env = []string{"RUNME=1"}
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%v\n%s", err, out)
+	}
+}

--- a/tmpl.go
+++ b/tmpl.go
@@ -29,6 +29,7 @@ func init() {
 	licenseTemplate["apache"] = template.Must(template.New("").Parse(tmplApache))
 	licenseTemplate["mit"] = template.Must(template.New("").Parse(tmplMIT))
 	licenseTemplate["bsd"] = template.Must(template.New("").Parse(tmplBSD))
+	licenseTemplate["mpl"] = template.Must(template.New("").Parse(tmplMPL))
 }
 
 type copyrightData struct {
@@ -94,3 +95,7 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.`
+
+const tmplMPL = `This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at https://mozilla.org/MPL/2.0/.`


### PR DESCRIPTION
Adds support for generating MPL license headers.

Includes one additional test.

Updated README to include `mpl` option also.

@x1ddos 