### PR TITLE
Add support for .mjs and .cjs JavaScript file extensions

### DIFF
--- a/main.go
+++ b/main.go
@@ -207,7 +207,7 @@ func licenseHeader(path string, tmpl *template.Template, data *copyrightData) ([
 		return nil, nil
 	case ".c", ".h":
 		lic, err = prefix(tmpl, data, "/*", " * ", " */")
-	case ".js", ".jsx", ".tsx", ".css", ".tf", ".ts":
+	case ".js", ".mjs", ".cjs", ".jsx", ".tsx", ".css", ".tf", ".ts":
 		lic, err = prefix(tmpl, data, "/**", " * ", " */")
 	case ".cc", ".cpp", ".cs", ".go", ".hh", ".hpp", ".java", ".m", ".mm", ".proto", ".rs", ".scala", ".swift", ".dart", ".groovy", ".kt", ".kts":
 		lic, err = prefix(tmpl, data, "", "// ", "")

--- a/testdata/expected/file.cjs
+++ b/testdata/expected/file.cjs
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function dummy() {
+  console.log('hello world!');
+}
+
+module.exports = dummy
+

--- a/testdata/expected/file.mjs
+++ b/testdata/expected/file.mjs
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+function dummy() {
+  console.log('hello world!');
+}
+
+export default dummy
+

--- a/testdata/initial/file.cjs
+++ b/testdata/initial/file.cjs
@@ -1,0 +1,6 @@
+function dummy() {
+  console.log('hello world!');
+}
+
+module.exports = dummy
+

--- a/testdata/initial/file.mjs
+++ b/testdata/initial/file.mjs
@@ -1,0 +1,6 @@
+function dummy() {
+  console.log('hello world!');
+}
+
+export default dummy
+


### PR DESCRIPTION
Many JavaScript packages support the `.mjs` and `.cjs` JavaScript file extensions.

For example, a popular JavaScript testing library, [ava](https://github.com/avajs/ava), [allows an `ava.config.cjs` JavaScript file](https://github.com/avajs/ava/blob/master/docs/06-configuration.md#avaconfigcjs) . It also supports other file extensions, but `.cjs` indicates it's a CommonJS module.

Babel also [supports `.mjs` and `.cjs`](https://babeljs.io/docs/en/config-files#supported-file-extensions).