### PR TITLE
Add missing license headers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,17 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 dist: bionic
 git:
   depth: 3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,17 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM golang:1-alpine AS build-env
 
 RUN apk add --no-cache --upgrade git openssh-client ca-certificates


### PR DESCRIPTION
From https://opensource.google/docs/releasing/preparing/ :

> BEST PRACTICE: Add license headers to any files that can be added to (i.e. anything that takes the format of a source file and supports file comments). This would include things like YAML files.

I believe this very directly applies to `.travis.yml`, and reasonably also applies to `Dockerfile`. Wasn't sure what year to put, just copy-pasted the license header from an existing Go source file and changed the commenting syntax.

(BTW, I mentioned this in the relevant (but internal to Google) b/165621580.)