### PR TITLE
Fix docker build failure due to upstream golang/dep deprecation unfixed issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:1-alpine AS build-env
 
 RUN apk add --no-cache --upgrade git openssh-client ca-certificates
+RUN go env -w GO111MODULE=off
 RUN go get -u github.com/golang/dep/cmd/dep
 WORKDIR /go/src/app
 


### PR DESCRIPTION
Fixes #71 
Uses suggestion from upstream Issue at https://github.com/golang/dep/issues/2223#issuecomment-599872151