### PR TITLE
fix building docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ docker run -it google/addlicense -h
 
 - Usage example
 ```bash
-docker run -v ${PWD}:/go/src/app/ -it google/addlicense -c "Google LLC" *.go
+docker run -v ${PWD}:/src -it google/addlicense -c "Google LLC" *.go
 ```
 
 ## license


### PR DESCRIPTION
Use go modules instead of dep.  Use two stage build to build a minimal (4 MB) application image.

Fixes #51 #71 #78