### PR TITLE
support ignoring file or directories

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,7 +5,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.x, 1.15.x]
+        go-version: [1.x, 1.16.x]
         platform: [ubuntu-latest]
         include:
           # only update test coverage stats with the most recent go version on linux

--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ to any file that already has one.
     -l license type: apache, bsd, mit, mpl (defaults to "apache")
     -y year (defaults to current year)
     -check check only mode: verify presence of license headers and exit with non-zero code if missing
+    -ignore file patterns to ignore, for example: -ignore **/*.go -ignore vendor/**
 
 The pattern argument can be provided multiple times, and may also refer
 to single files.
+
+The `-ignore` flag can use any pattern [supported by
+doublestar](https://github.com/bmatcuk/doublestar#patterns).
 
 ## Running in a Docker Container
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ by scanning directory patterns recursively.
 It modifies all source files in place and avoids adding a license header
 to any file that already has one.
 
+addlicense requires go 1.16 or later.
+
 ## install
 
     go get -u github.com/google/addlicense

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/google/addlicense
 
 go 1.13
 
-require golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+require (
+	github.com/bmatcuk/doublestar/v4 v4.0.2
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/bmatcuk/doublestar/v4 v4.0.2 h1:X0krlUVAVmtr2cRoTqR8aDMrDqnB36ht8wpWTiQ3jsA=
+github.com/bmatcuk/doublestar/v4 v4.0.2/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=


### PR DESCRIPTION
use the [doublestar library](https://github.com/bmatcuk/doublestar) to support pattern matching of files or directories to ignore. This replaces (and deprecates) the previous `-skip` flag which only supported file extensions.

(previous discussion in https://github.com/google/addlicense/pull/70#issuecomment-888695051)

The doublestar library requires go1.16, so I'm leaving this is draft mode until go1.17 is released (which should be any day now).

/cc @Shikugawa @laurentsimon @Shabirmean @lukehinds @cpanato - you've all been involved in similar implementations in #70, #73, and #75, so I'm curious if this implementation meets your use cases.