### PR TITLE
add support for cmake files

### DIFF
--- a/main.go
+++ b/main.go
@@ -306,6 +306,11 @@ func licenseHeader(path string, tmpl *template.Template, data licenseData) ([]by
 		lic, err = executeTemplate(tmpl, data, "", "// ", "")
 	case ".ml", ".mli", ".mll", ".mly":
 		lic, err = executeTemplate(tmpl, data, "(**", "   ", "*)")
+	default:
+		// handle various cmake files
+		if base == "cmakelists.txt" || strings.HasSuffix(base, ".cmake.in") || strings.HasSuffix(base, ".cmake") {
+			lic, err = executeTemplate(tmpl, data, "", "# ", "")
+		}
 	}
 	return lic, err
 }

--- a/main.go
+++ b/main.go
@@ -277,12 +277,15 @@ func fileHasLicense(path string) (bool, error) {
 	return hasLicense(b) || isGenerated(b), nil
 }
 
+// licenseHeader populates the provided license template with data, and returns
+// it with the proper prefix for the file type specified by path. The file does
+// not need to actually exist, only its name is used to determine the prefix.
 func licenseHeader(path string, tmpl *template.Template, data licenseData) ([]byte, error) {
 	var lic []byte
 	var err error
-	switch fileExtension(path) {
-	default:
-		return nil, nil
+	base := strings.ToLower(filepath.Base(path))
+
+	switch fileExtension(base) {
 	case ".c", ".h", ".gv", ".java", ".scala", ".kt", ".kts":
 		lic, err = executeTemplate(tmpl, data, "/*", " * ", " */")
 	case ".js", ".mjs", ".cjs", ".jsx", ".tsx", ".css", ".scss", ".sass", ".tf", ".ts":
@@ -307,11 +310,13 @@ func licenseHeader(path string, tmpl *template.Template, data licenseData) ([]by
 	return lic, err
 }
 
+// fileExtension returns the file extension of name, or the full name if there
+// is no extension.
 func fileExtension(name string) string {
 	if v := filepath.Ext(name); v != "" {
-		return strings.ToLower(v)
+		return v
 	}
-	return strings.ToLower(filepath.Base(name))
+	return name
 }
 
 var head = []string{

--- a/main_test.go
+++ b/main_test.go
@@ -339,6 +339,16 @@ func TestLicenseHeader(t *testing.T) {
 			[]string{"f.ml", "f.mli", "f.mll", "f.mly"},
 			"(**\n   HYS\n*)\n\n",
 		},
+		{
+			[]string{"cmakelists.txt", "f.cmake", "f.cmake.in"},
+			"# HYS\n\n",
+		},
+
+		// ensure matches are case insenstive
+		{
+			[]string{"F.PY", "DoCkErFiLe"},
+			"# HYS\n\n",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Add support for cmake files, adapted from #67

Slight refactoring in `licenseHeader()` and `fileExtension()` to make this and other future logic for determining license comment prefix a little cleaner.

Closes #67