### PR TITLE
docs: update docker instructions to include GitHub container registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,20 +31,30 @@ doublestar](https://github.com/bmatcuk/doublestar#patterns).
 
 ## Running in a Docker Container
 
-- Clone the repository using `git clone https://github.com/google/addlicense.git`
-- Build your docker container
+The simplest way to get the addlicense docker image is to pull from GitHub
+Container Registry:
+
 ```bash
-docker build -t google/addlicense .
+docker pull ghcr.io/google/addlicense:latest
 ```
 
-- Test the image
+Alternately, you can build it from source yourself:
+
 ```bash
-docker run -it google/addlicense -h
+docker build -t ghcr.io/google/addlicense .
 ```
 
-- Usage example
+Once you have the image, you can test that it works by running:
+
 ```bash
-docker run -v ${PWD}:/src -it google/addlicense -c "Google LLC" *.go
+docker run -it ghcr.io/google/addlicense -h
+```
+
+Finally, to run it, mount the directory you want to scan to `/src` and pass the
+appropriate addlicense flags:
+
+```bash
+docker run -it ghcr.io/google/addlicense -v ${PWD}:/src -c "Google LLC" *.go
 ```
 
 ## license


### PR DESCRIPTION
I don't *love* using `ghcr.io/google/addlicense` even for the local build instructions (rather than just `google/addlicense`), but it does make the later instructions to test and run the image consistent.  At the end of the day, probably not a big deal.