### PR TITLE
Add `.graphql` support

### DIFF
--- a/main.go
+++ b/main.go
@@ -318,7 +318,7 @@ func licenseHeader(path string, tmpl *template.Template, data licenseData) ([]by
 	case
 		".bzl", "build", ".build",
 		".dockerfile", "dockerfile",
-		".graphql"
+		".graphql",
 		".pl",
 		".pp",
 		".py",

--- a/main.go
+++ b/main.go
@@ -293,7 +293,7 @@ func licenseHeader(path string, tmpl *template.Template, data licenseData) ([]by
 		lic, err = executeTemplate(tmpl, data, "/**", " * ", " */")
 	case ".cc", ".cpp", ".cs", ".go", ".hcl", ".hh", ".hpp", ".m", ".mm", ".proto", ".rs", ".swift", ".dart", ".groovy", ".v", ".sv":
 		lic, err = executeTemplate(tmpl, data, "", "// ", "")
-	case ".py", ".sh", ".yaml", ".yml", ".dockerfile", "dockerfile", ".rb", "gemfile", ".tcl", ".bzl", ".pl", ".pp":
+	case ".py", ".sh", ".yaml", ".yml", ".dockerfile", "dockerfile", ".rb", "gemfile", ".tcl", ".bzl", ".pl", ".pp", ".graphql":
 		lic, err = executeTemplate(tmpl, data, "", "# ", "")
 	case ".el", ".lisp":
 		lic, err = executeTemplate(tmpl, data, "", ";; ", "")

--- a/main_test.go
+++ b/main_test.go
@@ -316,7 +316,7 @@ func TestLicenseHeader(t *testing.T) {
 			"// HYS\n\n",
 		},
 		{
-			[]string{"f.py", "f.sh", "f.yaml", "f.yml", "f.dockerfile", "dockerfile", "f.rb", "gemfile", "f.tcl", "f.bzl", "f.pl", "f.pp"},
+			[]string{"f.py", "f.sh", "f.yaml", "f.yml", "f.dockerfile", "dockerfile", "f.rb", "gemfile", "f.tcl", "f.bzl", "f.pl", "f.pp", "f.graphql"},
 			"# HYS\n\n",
 		},
 		{

--- a/testdata/expected/file.graphql
+++ b/testdata/expected/file.graphql
@@ -1,0 +1,22 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+query HeroNameAndFriends {
+  hero {
+    name
+    friends {
+      name
+    }
+  }
+}

--- a/testdata/initial/file.graphql
+++ b/testdata/initial/file.graphql
@@ -1,0 +1,8 @@
+query HeroNameAndFriends {
+  hero {
+    name
+    friends {
+      name
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for `.graphql` files.
  
[As stated](https://dgraph.io/docs/graphql/schema/documentation/), GraphQL files support `#` comments, so this PR just adds `.graphql` to the already existing list of files that use this type of comments.
  
This is my first time writing a Golang code, it is not tested. However, it seems straightforward, so I'm sure it works.
  
CLA is signed.