### PR TITLE
Only log skipped files in verbose mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@ addlicense requires go 1.16 or later.
 
     addlicense [flags] pattern [pattern ...]
 
-    -c copyright holder (defaults to "Google LLC")
-    -f custom license file (no default)
-    -l license type: apache, bsd, mit, mpl (defaults to "apache")
-    -y year (defaults to current year)
-    -check check only mode: verify presence of license headers and exit with non-zero code if missing
+    -c      copyright holder (default "Google LLC")
+    -check  check only mode: verify presence of license headers and exit with non-zero code if missing
+    -f      license file
     -ignore file patterns to ignore, for example: -ignore **/*.go -ignore vendor/**
+    -l      license type: apache, bsd, mit, mpl (default "apache")
+    -s      Include SPDX identifier in license header. Set -s=only to only include SPDX identifier.
+    -v      verbose mode: print the name of the files that are modified
+    -y      copyright year(s) (default "2022")
 
 The pattern argument can be provided multiple times, and may also refer
 to single files.

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ var (
 	license   = flag.String("l", "apache", "license type: apache, bsd, mit, mpl")
 	licensef  = flag.String("f", "", "license file")
 	year      = flag.String("y", fmt.Sprint(time.Now().Year()), "copyright year(s)")
-	verbose   = flag.Bool("v", false, "verbose mode: print the name of the files that are modified")
+	verbose   = flag.Bool("v", false, "verbose mode: print the name of the files that are modified or were skipped")
 	checkonly = flag.Bool("check", false, "check only mode: verify presence of license headers and exit with non-zero code if missing")
 )
 
@@ -217,7 +217,9 @@ func walk(ch chan<- *file, start string) error {
 			return nil
 		}
 		if fileMatches(path, ignorePatterns) {
-			log.Printf("skipping: %s", path)
+			if *verbose {
+				log.Printf("skipping: %s", path)
+			}
 			return nil
 		}
 		ch <- &file{path, fi.Mode()}


### PR DESCRIPTION
This PR changes the default behavior of logging all skipped files to instead logging the skipped files only in verbose mode (with `-v` flag). 

### Motivation

When a ton of files are skipped (e.g. `-ignore vendor/**`) then the output of `addlicense` becomes quite verbose and the actual output which we are interested in, i.e. which files were modified or which files are missing license info when `-check` is used, gets buried in between the `skipping` log lines.

P.S. I have also updated the usage instructions in the README with the up-to-date flag information as per `addlicense --help`.