### PR TITLE
.github: bump version of golangci-lint

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -18,4 +18,4 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.45
+        version: v1.50.1


### PR DESCRIPTION
I believe this should fix the lint failures we're seeing.