### PR TITLE
fix(readme): Update the docs to show current year

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ addlicense requires go 1.16 or later.
     -l      license type: apache, bsd, mit, mpl (default "apache")
     -s      Include SPDX identifier in license header. Set -s=only to only include SPDX identifier.
     -v      verbose mode: print the name of the files that are modified
-    -y      copyright year(s) (default "2022")
+    -y      copyright year(s) (default is the current year)
 
 The pattern argument can be provided multiple times, and may also refer
 to single files.  Directories are processed recursively.


### PR DESCRIPTION
The default for `year` is actually the current year, so this will update the documentation to reflect that