### PR TITLE
feat: Add pre-commit.com hook config to allow easy usage with pre-commit configs

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+- id: addlicense
+  name: Add copyright headers
+  entry: addlicense
+  language: golang
+  types: [text]


### PR DESCRIPTION
This allows easily using `addlicense` with pre-commit.com hook configs to automatically run
when committing.

An example example `.pre-commit-config.yaml` for a user would look like:

```
- repo: https://github.com/google/addlicense
    rev: <git tag>
    hooks:
      - id: addlicense
        args: [-l, apache, -c, "Copyright Owner"]
```

And under the hood, `pre-commit` will `go install` the `addlicense` program and run it on the affected files with the specified args.