### PR TITLE
Fix ignore on Windows

### DIFF
--- a/main.go
+++ b/main.go
@@ -230,6 +230,8 @@ func walk(ch chan<- *file, start string) error {
 // fileMatches determines if path matches one of the provided file patterns.
 // Patterns are assumed to be valid.
 func fileMatches(path string, patterns []string) bool {
+	// handle both \ and /
+	path = filepath.ToSlash(path)
 	for _, p := range patterns {
 		// ignore error, since we assume patterns are valid
 		if match, _ := doublestar.Match(p, path); match {


### PR DESCRIPTION
`fileMatches` will receive paths with native path separators(i.e. `\` on Windows). Per the [doc](https://github.com/bmatcuk/doublestar/tree/v4?tab=readme-ov-file#match) `doublestar.Match` doesn't work as expected with `\`, and `filepath.ToSlash()` should be used to handle such case.