### PR TITLE
Support CMakeLists.txt naming convention

### DIFF
--- a/main.go
+++ b/main.go
@@ -313,7 +313,7 @@ func licenseHeader(path string, tmpl *template.Template, data licenseData) ([]by
 		lic, err = executeTemplate(tmpl, data, "(**", "   ", "*)")
 	default:
 		// handle various cmake files
-		if base == "cmakelists.txt" || strings.HasSuffix(base, ".cmake.in") || strings.HasSuffix(base, ".cmake") {
+		if base == "CMakeLists.txt" || base == "cmakelists.txt" || strings.HasSuffix(base, ".cmake.in") || strings.HasSuffix(base, ".cmake") {
 			lic, err = executeTemplate(tmpl, data, "", "# ", "")
 		}
 	}


### PR DESCRIPTION
addlicense seems not to work when the standard naming convention is used for CMakeLists.txt

https://cmake.org/cmake/help/book/mastering-cmake/chapter/Writing%20CMakeLists%20Files.html