### PR TITLE
Add `.pre-commit-hooks.yaml` to allow be run as a pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: addlicense
+  name: addlicense
+  description: Run addlicense to ensure source code files have copyright license headers
+  language: golang
+  entry: addlicense
+  minimum_pre_commit_version: 3.0.0  # pre-commit can bootstrap Go environment


### PR DESCRIPTION
As per the title, users can use `addlicense` as a pre-commit hook:

```yaml
# .pre-commit-config.yaml

repos:
  - repo: https://github.com/XuehaiPan/addlicense
    rev: '0a8669'
    hooks:
      - id: addlicense
        args: [-check, -l, apache, -c, "Some Team. All Rights Reserved."]
```