### PR TITLE
fix: ensure --check verifies correct copyright holder when -c flag is…

### DIFF
--- a/main.go
+++ b/main.go
@@ -342,13 +342,22 @@ func extractCopyrightHolder(filePath string) (string, error) {
 		return "", err
 	}
 
-	re := regexp.MustCompile(`(?i)Copyright\s+\d{4,}\s+(.+)`)
+	re := regexp.MustCompile(`(?i)Copyright\s*(?:\(c\))?\s*(?:\d{4}(?:-\d{4})?)?\s*(.+?)(?:\.|$|\n)`)
+
 	matches := re.FindStringSubmatch(string(content))
-	if len(matches) < 2 {
-		return "", nil
+
+	if len(matches) > 1 {
+		holder := strings.TrimSpace(matches[1])
+
+		if strings.Contains(holder, "\n") {
+			lines := strings.Split(holder, "\n")
+			holder = strings.TrimSpace(lines[0])
+		}
+
+		return holder, nil
 	}
 
-	return strings.TrimSpace(matches[1]), nil
+	return "", nil
 }
 
 // fileExtension returns the file extension of name, or the full name if there


### PR DESCRIPTION
### Description
This PR ensures that when using --check with -c "Copyright Holder", addlicense verifies that the copyright holder matches the expected value instead of just checking for a license header.

### Changes Made
Added extractCopyrightHolder to correctly extract and validate the copyright holder using regex.
Ensured default behavior remains unchanged when -c is not provided.

#### Test Output:

`addlicense -c "Google LLC" --check testdata/initial/file.cs`

##### Before Fix:

`testdata/expected/file.cs`

##### After Fix:

`testdata/expected/file.cs: incorrect copyright holder (expected: Google LLC, found: Meta Platforms)`

#### Tests & Verification
All unit tests passed successfully.

Closes #164 