### PR TITLE
Add test and handle if there is a "copyright" U+00A9 symbol

### DIFF
--- a/main.go
+++ b/main.go
@@ -431,5 +431,6 @@ func hasLicense(b []byte) bool {
 	}
 	return bytes.Contains(bytes.ToLower(b[:n]), []byte("copyright")) ||
 		bytes.Contains(bytes.ToLower(b[:n]), []byte("mozilla public")) ||
-		bytes.Contains(bytes.ToLower(b[:n]), []byte("spdx-license-identifier"))
+		bytes.Contains(bytes.ToLower(b[:n]), []byte("spdx-license-identifier")) ||
+		bytes.Contains(b[:n], []byte("©"))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -486,6 +486,7 @@ func TestHasLicense(t *testing.T) {
 		{"Subject to the terms of the Mozilla Public License", true},
 		{"SPDX-License-Identifier: MIT", true},
 		{"spdx-license-identifier: MIT", true},
+		{"©", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This will permit the interchange of "copyright" and the Unicode symbol U+00A9 to be interchanged.