### PR TITLE
Add VHDL support

### DIFF
--- a/main.go
+++ b/main.go
@@ -350,7 +350,8 @@ func licenseHeader(path string, tmpl *template.Template, data licenseData) ([]by
 	case
 		".hs",
 		".lua",
-		".sql", ".sdl":
+		".sql", ".sdl",
+		".vhdl", ".vhd":
 		lic, err = executeTemplate(tmpl, data, "", "-- ", "")
 	case
 		".html", ".htm",

--- a/main_test.go
+++ b/main_test.go
@@ -385,6 +385,7 @@ func TestLicenseHeader(t *testing.T) {
 				"f.hs",
 				"f.lua",
 				"f.sql", "f.sdl",
+				"f.vhdl", "f.vhd",
 			},
 			"-- HYS\n\n",
 		},

--- a/testdata/expected/file.vhd
+++ b/testdata/expected/file.vhd
@@ -1,0 +1,23 @@
+-- Copyright 2018 Google LLC
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+library ieee;
+  use ieee.std_logic_1164.all;
+
+entity test is
+end entity test;
+
+architecture minimal of test is
+begin
+end architecture minimal;

--- a/testdata/initial/file.vhd
+++ b/testdata/initial/file.vhd
@@ -1,0 +1,9 @@
+library ieee;
+  use ieee.std_logic_1164.all;
+
+entity test is
+end entity test;
+
+architecture minimal of test is
+begin
+end architecture minimal;


### PR DESCRIPTION
This PR adds support to VHDL hardware description language files (IEEE Std 1076) with extensions `.vhd` and `.vhdl`