### PR TITLE
Add support to FuseSoC files

### DIFF
--- a/main.go
+++ b/main.go
@@ -323,6 +323,7 @@ func licenseHeader(path string, tmpl *template.Template, data licenseData) ([]by
 		".awk",
 		".buckconfig", "buck",
 		".bzl", ".bazel", "build", ".build",
+		".core",
 		".dockerfile", "dockerfile",
 		".ex", ".exs",
 		".fpp",
@@ -395,6 +396,7 @@ var head = []string{
 	"<?php",                    // PHP opening tag
 	"# escape",                 // Dockerfile directive https://docs.docker.com/engine/reference/builder/#parser-directives
 	"# syntax",                 // Dockerfile directive https://docs.docker.com/engine/reference/builder/#parser-directives
+	"capi=",                    // FuseSoC .core files
 }
 
 func hashBang(b []byte) []byte {

--- a/main_test.go
+++ b/main_test.go
@@ -245,6 +245,7 @@ func TestAddLicense(t *testing.T) {
 		{"<?php\ncontent", "<?php\n// HYS\n\ncontent", true},
 		{"# escape: `\ncontent", "# escape: `\n// HYS\n\ncontent", true},
 		{"# syntax: docker/dockerfile:1.3\ncontent", "# syntax: docker/dockerfile:1.3\n// HYS\n\ncontent", true},
+		{"CAPI=2:\ncontent", "CAPI=2:\n// HYS\n\ncontent", true},
 
 		// ensure files with existing license or generated files are
 		// skipped. No need to test all permutations of these, since
@@ -348,6 +349,7 @@ func TestLicenseHeader(t *testing.T) {
 				"f.awk",
 				"f.buckconfig", "buck",
 				"f.bzl", "f.bazel", "build", "f.build",
+				"f.core",
 				"f.dockerfile", "dockerfile",
 				"f.ex", "f.exs",
 				"f.graphql",

--- a/testdata/expected/test.core
+++ b/testdata/expected/test.core
@@ -1,0 +1,22 @@
+CAPI=2:
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: test:core:unit:1.0.0
+
+filesets:
+  rtl:
+    files:
+      - pe.vhd
+    file_type: vhdlSource

--- a/testdata/initial/test.core
+++ b/testdata/initial/test.core
@@ -1,0 +1,8 @@
+CAPI=2:
+name: test:core:unit:1.0.0
+
+filesets:
+  rtl:
+    files:
+      - pe.vhd
+    file_type: vhdlSource


### PR DESCRIPTION
This PR adds support to [FuseSoC](https://fusesoc.readthedocs.io/en/stable/user/index.html) [Core API v2 files](https://fusesoc.readthedocs.io/en/stable/ref/capi2.html) (extension `.core`).

This YAML-based file format requires a fixed header (`CAPI=2:`) being present at the beginning of the file.